### PR TITLE
Update pods.

### DIFF
--- a/BoxBrowseSDK/BoxBrowseSDK.xcodeproj/project.pbxproj
+++ b/BoxBrowseSDK/BoxBrowseSDK.xcodeproj/project.pbxproj
@@ -203,6 +203,7 @@
 		15CE0A071ACD15BA006B8614 /* DummyStrings.m in Sources */ = {isa = PBXBuildFile; fileRef = 15CE0A061ACD15BA006B8614 /* DummyStrings.m */; };
 		15CE0A0A1ACDEE1A006B8614 /* BOXItemsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 15CE0A091ACDEE1A006B8614 /* BOXItemsViewController.m */; };
 		15CE0A0B1ACDEE1A006B8614 /* BOXItemsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 15CE0A091ACDEE1A006B8614 /* BOXItemsViewController.m */; };
+		15DC5B261AE01EFE003FB3E9 /* BOXItemCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 1564A5541ACA1D68005DD04F /* BOXItemCell.m */; };
 		1C6E5394A7F19AE4673FFCCC /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A03A2EFCE068CBE5D11D74D /* libPods.a */; };
 		C1E7651D66F260349D91B959 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A03A2EFCE068CBE5D11D74D /* libPods.a */; };
 /* End PBXBuildFile section */
@@ -1153,6 +1154,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				15DC5B261AE01EFE003FB3E9 /* BOXItemCell.m in Sources */,
 				15764E0D1ACF42710023C535 /* BOXSearchResultsViewController.m in Sources */,
 				1564A5371ACA12D1005DD04F /* UIImage+BOXBrowseSDKAdditions.m in Sources */,
 				1564A6DA1ACB3C9E005DD04F /* BOXThumbnailCache.m in Sources */,

--- a/BoxBrowseSDK/BoxBrowseSDK/BOXItemsViewController.m
+++ b/BoxBrowseSDK/BoxBrowseSDK/BOXItemsViewController.m
@@ -10,8 +10,6 @@
 #import "BOXItemCell.h"
 #import "BOXFolderViewController.h"
 
-#define kCellHeight 50.0
-
 @interface BOXItemsViewController ()
 
 @property (nonatomic, readwrite, strong) NSArray *items;
@@ -37,7 +35,6 @@
     [super viewDidLoad];
     
     self.tableView.separatorInset = UIEdgeInsetsZero;
-    self.tableView.rowHeight = kCellHeight;
     self.tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectZero]; // eliminate extra separators
     
     [self setupNavigationBar];

--- a/BoxBrowseSDKSampleApp/Podfile.lock
+++ b/BoxBrowseSDKSampleApp/Podfile.lock
@@ -18,8 +18,8 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  box-ios-browse-sdk: 0f9e4be0b3671309de4d307e1638bd0e4f98a979
-  box-ios-content-sdk: cbb0e9a99be49af61d60678c773ce63dac4e4300
+  box-ios-browse-sdk: 41d016f0036dd68255e37db1ea7af3d80692ff84
+  box-ios-content-sdk: 7b572c3ba051a167e526c6fce21abac49970bf9f
   MBProgressHUD: c47f2c166c126cf2ce36498d80f33e754d4e93ad
 
 COCOAPODS: 0.36.3


### PR DESCRIPTION
Also:
Fixed compile error when building the SDK standalone due to missing ref in test target.
Removed duplicate cell height definition.
