### PR TITLE
Fixed thumbnail issues:

### DIFF
--- a/BoxBrowseSDK/BoxBrowseSDK/BOXItemCell.m
+++ b/BoxBrowseSDK/BoxBrowseSDK/BOXItemCell.m
@@ -112,17 +112,18 @@ CGFloat const BOXItemCellHeight = 60.0f;
                 }
             }];
         } else {
-            self.myImageView.image = [self iconForItem:item];
+            UIImageView *myImageView = self.myImageView;
+            myImageView.image = [self iconForItem:item];
             self.thumbnailRequest = [thumbnailCache fetchThumbnailForFile:file size:BOXThumbnailSize128 completion:^(UIImage *image, NSError *error) {
-                if ([me.item.modelID isEqualToString:file.modelID]) {
-                    dispatch_async(dispatch_get_main_queue(), ^{
-                        me.myImageView.image = image;
+                if (error == nil) {
+                    if ([me.item.modelID isEqualToString:file.modelID]) {
+                        myImageView.image = image;
                         CATransition *transition = [CATransition animation];
                         transition.duration = 0.3f;
                         transition.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
                         transition.type = kCATransitionFade;
-                        [me.imageView.layer addAnimation:transition forKey:nil];
-                    });
+                        [myImageView.layer addAnimation:transition forKey:nil];
+                    }
                 }
             }];
         }

--- a/BoxBrowseSDK/BoxBrowseSDK/BOXItemsViewController.h
+++ b/BoxBrowseSDK/BoxBrowseSDK/BOXItemsViewController.h
@@ -70,8 +70,6 @@
  *
  *  @param folder The folder the user selected.
  *  @param items The list of items that the tap occured from. The array will include the tapped item itself.
- *
- *  @return Whether or not to navigate to the folder. If YES, the user will be taken into the folder.
  */
 - (void)didTapFolder:(BOXFolder *)folder inItems:(NSArray *)items;
 

--- a/BoxBrowseSDK/BoxBrowseSDK/BOXThumbnailCache.m
+++ b/BoxBrowseSDK/BoxBrowseSDK/BOXThumbnailCache.m
@@ -74,7 +74,7 @@
 
 - (NSString *)cacheKeyForFile:(BOXFile *)file thumbnailSize:(BOXThumbnailSize)thumbnailSize
 {
-    NSString *key = [NSString stringWithFormat:@"%@_%lu", file, thumbnailSize];
+    NSString *key = [NSString stringWithFormat:@"%@_%lu", file.SHA1, thumbnailSize];
     return key;
 }
 


### PR DESCRIPTION
1. Thumbnails were not fading in with animation because we were trying to add
   animation to a weak ref.
2. Thumbnail cache was keyed off of an actual BOXFile object instead of a SHA1.
   So it never returned cached images for multiple instances of BOXFile objects
   that point to the same File.
- Also removed incorrect documentation on didTapFolder.
