### PR TITLE
Converted some properties that were being used to configure the View Controller into delegate methods.

### DIFF
--- a/BoxBrowseSDK/BoxBrowseSDK/BOXFolderViewController.h
+++ b/BoxBrowseSDK/BoxBrowseSDK/BOXFolderViewController.h
@@ -13,37 +13,13 @@
 
 @interface BOXFolderViewController : BOXItemsViewController
 
+@property (nonatomic, readonly, strong) NSString *folderID;
+
 - (instancetype)initWithContentClient:(BOXContentClient *)contentClient
                              folderID:(NSString *)folderID;
 
 - (instancetype)initWithContentClient:(BOXContentClient *)contentClient
                                folder:(BOXFolder *)folder;
-
-/**
- *  Defaults to YES. If YES, a search bar will be shown as a table header view to allow users to search for content within the 
- *  folder that is being viewed.
- */
-@property (nonatomic, readwrite, assign) BOOL showsSearchBar;
-
-/**
- *  Defaults to NO. If YES, a toolbar button item will be added that allows users to "Choose" the folder they are currently viewing.
- *  This could be useful if you are asking users to choose a folder from Box.
- *  The chosen folder will be returned through 'didTapChooseFolderButton:'.
- */
-@property (nonatomic, readwrite, assign) BOOL showsChooseFolderButton;
-
-/**
- *  Defaults to NO. If YES, a toolbar button item will be added that allows users to create a new folder in the folder they are currently viewing.
- *  By default, this button will not be shown.
- *  A newly created folder will be returned through 'didCreateNewFolder:'
- */
-@property (nonatomic, readwrite, assign) BOOL showsCreateFolderButton;
-
-/**
- *  The flag that sets whether deletion is allowed by user. Default to YES.
- *  If YES, a delete button is exposed when an item row is swiped.
- */
-@property (nonatomic, readwrite, assign) BOOL showsDeleteButtons;
 
 @end
 
@@ -55,7 +31,7 @@
  *  If the choose button is shown (see 'shouldShowChooseFolderButton'), this will be called when the user has tapped the button to
  *  select the folder currently displayed.
  *
- *  @param itemsViewController The instance of BOXItemsViewController calling this method.
+ *  @param folderViewController The instance of BOXFolderViewController calling this method.
  *  @param folder The Folder that the user was viewing when the Choose button was tapped.
  */
 - (void)folderViewController:(BOXFolderViewController *)folderViewController didChooseFolder:(BOXFolder *)folder;
@@ -63,7 +39,7 @@
 /**
  *  A folder was created.
  *
- *  @param itemsViewController The instance of BOXItemsViewController calling this method.
+ *  @param folderViewController The instance of BOXFolderViewController calling this method.
  *  @param folder The created folder.
  */
 - (void)folderViewController:(BOXFolderViewController *)folderViewController didCreateNewFolder:(BOXFolder *)folder;
@@ -71,9 +47,47 @@
 /**
  *  A Box item was deleted.
  *
- *  @param itemsViewController The instance of BOXItemsViewController calling this method.
+ *  @param folderViewController The instance of BOXFolderViewController calling this method.
  *  @param item The deleted item.
  */
 - (void)folderViewController:(BOXFolderViewController *)folderViewController didDeleteItem:(BOXItem *)item;
+
+/**
+ *  Whether to expose a 'Delete' button for an item by swiping the cell. By default this is not exposed. Note that depending on permissions
+ *  the 'Delete' action may not be exposed even if YES is returned.
+ *
+ *  @param folderViewController The instance of BOXFolderViewController calling this method.
+ *  @param item The deleted item to show/hide the delete button for.
+ *  @return YES to show the 'Delete' actiion, NO otherwise.
+ */
+- (BOOL)folderViewController:(BOXFolderViewController *)folderViewController shouldShowDeleteButtonForItem:(BOXItem *)item;
+
+/**
+ *  Whether to show a search bar to allow the user to search for content within the folder.
+ *  By default, a search bar is shown.
+ *
+ *  @param folderViewController The instance of BOXFolderViewController calling this method.
+ *  @return YES to show a search bar, NO otherwise.
+ */
+- (BOOL)folderViewControllerShouldShowSearchBar:(BOXFolderViewController *)folderViewController;
+
+/**
+ *  Whether to show a button to 'Choose' the folder being displayed. This might be appropriate in
+ *  scenarios where you are asking the user to select a folder (e.g. a folder to upload to).
+ *  By default, this button is not displayed.
+ *
+ *  @param folderViewController The instance of BOXFolderViewController calling this method.
+ *  @return YES to show a the button, NO otherwise.
+ */
+- (BOOL)folderViewControllerShouldShowChooseFolderButton:(BOXFolderViewController *)folderViewController;
+
+/**
+ *  Whether to show a button to allow the user to create a new folder within the folder displayed.
+ *  By default, this button is not displayed.
+ *
+ *  @param folderViewController The instance of BOXFolderViewController calling this method.
+ *  @return YES to show a the button, NO otherwise.
+ */
+- (BOOL)folderViewControllerShouldShowCreateFolderButton:(BOXFolderViewController *)folderViewController;
 
 @end

--- a/BoxBrowseSDK/BoxBrowseSDK/BOXItemsViewController.h
+++ b/BoxBrowseSDK/BoxBrowseSDK/BOXItemsViewController.h
@@ -28,11 +28,6 @@
  */
 - (void)refresh;
 
-/**
- * Controls whether or not to show the close button in the navigation bar.
- */
-@property (nonatomic, readwrite, assign) BOOL showsCloseButton;
-
 @end
 
 @protocol BOXItemsViewControllerDelegate <NSObject>
@@ -120,5 +115,16 @@
  *  @return YES to allow the navigation to proceed, false otherwise.
  */
 - (BOOL)itemsViewController:(BOXItemsViewController *)itemsViewController willNavigateToFolder:(BOXFolder *)folder;
+
+/**
+ *
+ *  Whether or not to show a 'Close' button in the navigation bar. By default, the button will be shown and
+ *  will dismiss the host UINavigationController when tapped.
+ *
+ *  @param itemsViewController The instance of BOXItemsViewController calling this method.
+ *
+ *  @return YES to show the button, NO otherwise.
+ */
+- (BOOL)itemsViewControllerShouldShowCloseButton:(BOXItemsViewController *)itemsViewController;
 
 @end

--- a/BoxBrowseSDK/BoxBrowseSDK/BOXItemsViewController.m
+++ b/BoxBrowseSDK/BoxBrowseSDK/BOXItemsViewController.m
@@ -137,7 +137,12 @@
 - (void)setupNavigationBar
 {
     // Close Button
-    if (self.showsCloseButton) {
+    BOOL shouldShowCloseButton = YES;
+    if ([self.delegate respondsToSelector:@selector(itemsViewControllerShouldShowCloseButton:)]) {
+        shouldShowCloseButton = [self.delegate itemsViewControllerShouldShowCloseButton:self];
+    }
+    
+    if (shouldShowCloseButton) {
         UIBarButtonItem *closeBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Close", @"Title : button closing the folder picker")
                                                                                style:UIBarButtonItemStylePlain
                                                                               target:self

--- a/BoxBrowseSDK/BoxBrowseSDK/BOXSearchResultsViewController.m
+++ b/BoxBrowseSDK/BoxBrowseSDK/BOXSearchResultsViewController.m
@@ -62,7 +62,6 @@
         }
         if (shouldNavigateToFolder) {
             BOXFolderViewController *viewController = [[BOXFolderViewController alloc] initWithContentClient:self.contentClient folder:folder];
-            viewController.showsCloseButton = self.showsCloseButton;
             viewController.delegate = self.folderBrowserDelegate;
             if ([[self class] isKindOfClass:[BOXFolderViewController class]]) {
                 viewController.showsChooseFolderButton = ((BOXFolderViewController *)self).showsChooseFolderButton;

--- a/BoxBrowseSDKSampleApp/BoxBrowseSDKSampleApp/AppDelegate.m
+++ b/BoxBrowseSDKSampleApp/BoxBrowseSDKSampleApp/AppDelegate.m
@@ -19,10 +19,8 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-//    #error Set your client-id and client-secret that you obtained from https://developers.box.com
-//    [BOXContentClient setClientID:nil clientSecret:nil];
-
-    [BOXContentClient setClientID:@"m8nwyiz20tq7j9itkz3loab9rwsgwa1y" clientSecret:@"cVDIgTy6WFQ8RbUKSSgNxlzl4ej59KvO"];
+    #error Set your client-id and client-secret that you obtained from https://developers.box.com
+    [BOXContentClient setClientID:nil clientSecret:nil];
 
     ViewController *viewController = [[ViewController alloc] init];
     self.window.rootViewController = viewController;

--- a/BoxBrowseSDKSampleApp/BoxBrowseSDKSampleApp/ViewController.m
+++ b/BoxBrowseSDKSampleApp/BoxBrowseSDKSampleApp/ViewController.m
@@ -44,9 +44,6 @@
     // Show a UIViewController that displays the contents of a Box Folder.
     BOXFolderViewController *folderViewController = [[BOXFolderViewController alloc] initWithContentClient:[BOXContentClient defaultClient]];
     folderViewController.delegate = self;
-    folderViewController.showsCreateFolderButton = YES;
-    folderViewController.showsChooseFolderButton = YES;
-    folderViewController.showsSearchBar = YES;
     
     // You must load it in a UINavigationController.
     self.navControllerForBrowseSDK = [[UINavigationController alloc] initWithRootViewController:folderViewController];
@@ -55,7 +52,14 @@
 
 #pragma mark - BOXFolderViewControllerDelegate
 
+////////////////////////////////////////////////////////////////////////////////////////
 // These are all optional and will allow you to customize behavior for your app.
+////////////////////////////////////////////////////////////////////////////////////////
+
+- (BOOL)itemsViewControllerShouldShowCloseButton:(BOXItemsViewController *)itemsViewController
+{
+    return NO;
+}
 
 - (BOOL)itemsViewController:(BOXItemsViewController *)itemsViewController shouldShowItem:(BOXItem *)item
 {
@@ -100,9 +104,19 @@
 //{
 //}
 
+- (BOOL)folderViewControllerShouldShowChooseFolderButton:(BOXFolderViewController *)folderViewController
+{
+    return YES;
+}
+
 - (void)folderViewController:(BOXFolderViewController *)folderViewController didChooseFolder:(BOXFolder *)folder
 {
     NSLog(@"Did choose folder: %@", folder.name);
+}
+
+- (BOOL)folderViewControllerShouldShowCreateFolderButton:(BOXFolderViewController *)folderViewController
+{
+    return YES;
 }
 
 - (void)folderViewController:(BOXFolderViewController *)folderViewController didCreateNewFolder:(BOXFolder *)folder
@@ -110,9 +124,21 @@
     NSLog(@"Did create new folder: %@", folder.name);
 }
 
+- (BOOL)folderViewController:(BOXFolderViewController *)folderViewController shouldShowDeleteButtonForItem:(BOXItem *)item
+{
+    return YES;
+}
+
 - (void)folderViewController:(BOXFolderViewController *)folderViewController didDeleteItem:(BOXItem *)item
 {
     NSLog(@"Did delete item: %@", item.name);
 }
+
+- (BOOL)folderViewControllerShouldShowSearchBar:(BOXFolderViewController *)folderViewController
+{
+    return YES;
+}
+
+
 
 @end


### PR DESCRIPTION
- This will centralize the configurations into one place, and will also make it easier to instantiate
  new Items/FolderViewControllers that keep the same configurations.
- Logic moved: shouldShowCloseButton, shouldShowCreateFolderButton, shouldShowDeleteButtonForItem, shouldShowSearchBar
- Also removed the test clientID and clientSecret.
