### PR TITLE
Remove reference to internal Podspecs directory.

### DIFF
--- a/BoxBrowseSDK/Podfile
+++ b/BoxBrowseSDK/Podfile
@@ -1,4 +1,2 @@
-source 'https://github.com/box/box-ios-podspecs.git'
-source 'https://github.com/CocoaPods/Specs.git'
 pod 'box-ios-content-sdk'
 pod 'MBProgressHUD', '~> 0.9.1'

--- a/BoxBrowseSDKSampleApp/Podfile
+++ b/BoxBrowseSDKSampleApp/Podfile
@@ -1,3 +1,1 @@
-source 'https://github.com/box/box-ios-podspecs.git'
-source 'https://github.com/CocoaPods/Specs.git'
 pod 'box-ios-browse-sdk', :path => '../'

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Quickstart
 ----------
 Step 1: Add to your Podfile
 ```
-source 'https://github.com/box/box-ios-podspecs.git'
-source 'https://github.com/CocoaPods/Specs.git'
 pod 'box-ios-browse-sdk'
 ```
 Step 2: Install


### PR DESCRIPTION
We can merge this after successful submission to the global Cocoa Pods repo.

After merging this, remember to update the version tag.