### PR TITLE
Request all fields in search request so that we can properly present UI.

### DIFF
--- a/BoxBrowseSDK/BoxBrowseSDK/BOXSearchResultsViewController.m
+++ b/BoxBrowseSDK/BoxBrowseSDK/BOXSearchResultsViewController.m
@@ -39,6 +39,7 @@
     [self.searchRequest cancel];
     
     self.searchRequest = [self.contentClient searchRequestWithQuery:self.searchString inRange:NSMakeRange(0, 1000)];
+    self.searchRequest.requestAllItemFields = YES;
     self.searchRequest.SDKIdentifier = BOX_BROWSE_SDK_IDENTIFIER;
     self.searchRequest.SDKVersion = BOX_BROWSE_SDK_VERSION;
     self.searchRequest.ancestorFolderIDs = @[self.folderID];


### PR DESCRIPTION
- For example, the folder icons don't reflect collab status without this.
