### PR TITLE
Add ability to disable sorting of items in BOXItemsViewController.

### DIFF
--- a/BoxBrowseSDK/BoxBrowseSDK/BOXBrowseSDKConstants.h
+++ b/BoxBrowseSDK/BoxBrowseSDK/BOXBrowseSDKConstants.h
@@ -9,4 +9,4 @@
 #import <Foundation/Foundation.h>
 
 #define BOX_BROWSE_SDK_IDENTIFIER @"box-browse-sdk"
-#define BOX_BROWSE_SDK_VERSION @"1.0.2"
+#define BOX_BROWSE_SDK_VERSION @"1.0.4"

--- a/BoxBrowseSDK/BoxBrowseSDK/BOXItemsViewController.h
+++ b/BoxBrowseSDK/BoxBrowseSDK/BOXItemsViewController.h
@@ -58,6 +58,22 @@
 - (BOOL)itemsViewController:(BOXItemsViewController *)itemsViewController shouldEnableItem:(BOXItem *)item;
 
 /**
+ *  Override this method to enable or disable item sorting. This method sorts BOX folder item results for display.
+ *  By default, items will be sorted.
+ *
+ *  @param itemsViewController The instance of BOXItemsViewController calling this method.
+ *
+ *  @return YES to enable sorting (enabled by default). The default sort applied is:
+ *  1) Folders listed before files and weblinks
+ *  2) By modified date descending
+ *  3) Alpha-numeric ascending.
+ *  You can also implement itemsViewController:compareForSortingItem:toItem: for custom sorting.
+ *
+ *  @return NO to disable sorting.
+ */
+- (BOOL)itemsViewControllerShouldSortItems:(BOXItemsViewController *)itemsViewController;
+
+/**
  *  Implement this if you want to customize the sort order of items. By default items will be sorted with the following ordered rules:
  *  - Folders come before files and weblinks.
  *  - Most recently modified items come first.

--- a/BoxBrowseSDK/BoxBrowseSDK/BOXItemsViewController.m
+++ b/BoxBrowseSDK/BoxBrowseSDK/BOXItemsViewController.m
@@ -168,7 +168,13 @@
 {
     [self fetchItemsWithCompletion:^(NSArray *items) {
         items = [self filterItems:items];
-        items = [self sortItems:items];
+        BOOL shouldSort = YES;
+        if ([self.delegate respondsToSelector:@selector(itemsViewControllerShouldSortItems:)]) {
+            shouldSort = [self.delegate itemsViewControllerShouldSortItems:self];
+        }
+        if (shouldSort) {
+            items = [self sortItems:items];
+        }
         
         self.items = items;
         [self.tableView reloadData];

--- a/box-ios-browse-sdk.podspec
+++ b/box-ios-browse-sdk.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
 # Root specification
 
 s.name                  = "box-ios-browse-sdk"
-s.version               = "1.0.3"
+s.version               = "1.0.4"
 s.summary               = "iOS Browse SDK."
 s.homepage              = "https://github.com/box/box-ios-browse-sdk"
 s.license               = { :type => "Apache License, Version 2.0", :file => "LICENSE" }


### PR DESCRIPTION
- In some cases, developers just want to display their BOXItems in the order they
provided it, without any sorting done for display.