### PR TITLE
Don't set up a static NSBundle for image loading.

### DIFF
--- a/BoxBrowseSDK/BoxBrowseSDK/Categories/NSBundle+BOXBrowseSDKAdditions.m
+++ b/BoxBrowseSDK/BoxBrowseSDK/Categories/NSBundle+BOXBrowseSDKAdditions.m
@@ -13,14 +13,9 @@
 
 + (NSBundle *)boxBrowseSDKResourcesBundle
 {
-    static NSBundle *browseSDKResourceBundle = nil;
-    static dispatch_once_t predicate;
-    dispatch_once(&predicate, ^{
-        NSBundle *browseSDKBundle = [NSBundle bundleForClass:[BOXBrowseSDKResourceLocator class]];
-        NSString *browseSDKResourceBundlePath = [browseSDKBundle.bundlePath stringByAppendingPathComponent:@"BoxBrowseSDKResources.bundle"];
-        browseSDKResourceBundle = [NSBundle bundleWithPath:browseSDKResourceBundlePath];
-    });
-
+    NSBundle *browseSDKBundle = [NSBundle bundleForClass:[BOXBrowseSDKResourceLocator class]];
+    NSString *browseSDKResourceBundlePath = [browseSDKBundle.bundlePath stringByAppendingPathComponent:@"BoxBrowseSDKResources.bundle"];
+    NSBundle *browseSDKResourceBundle = [NSBundle bundleWithPath:browseSDKResourceBundlePath];
     return browseSDKResourceBundle;
 }
 


### PR DESCRIPTION
It can cause problems when multiple threads are trying to load images.

This is an attempt to fix crashes like these:
https://fabric.io/box/ios/apps/net.box.boxnet/issues/5702c7c6ffcdc042506c199d

Unable to reproduce so this is a theoretical fix.