### PR TITLE
Crash getting resources from bundle

### DIFF
--- a/BoxBrowseSDK/BoxBrowseSDK/Categories/UIImage+BOXBrowseSDKAdditions.m
+++ b/BoxBrowseSDK/BoxBrowseSDK/Categories/UIImage+BOXBrowseSDKAdditions.m
@@ -20,24 +20,38 @@
 
     UIImage *icon = nil;
 
-    if (item.isFolder) {
-        BOXFolder *folder = (BOXFolder *)item;
-        if (folder.isExternallyOwned == BOXAPIBooleanYES) {
-            icon = [UIImage imageNamed:@"icon-folder-external" inBundle:browseResourceBundle compatibleWithTraitCollection:nil];
-        } else if (folder.hasCollaborations == BOXAPIBooleanYES) {
-            icon = [UIImage imageNamed:@"icon-folder-shared" inBundle:browseResourceBundle compatibleWithTraitCollection:nil];
-        } else {
-            icon = [UIImage imageNamed:@"icon-folder" inBundle:browseResourceBundle compatibleWithTraitCollection:nil];
+    @synchronized (browseResourceBundle) {
+        if (item.isFolder) {
+            BOXFolder *folder = (BOXFolder *)item;
+            if (folder.isExternallyOwned == BOXAPIBooleanYES) {
+                icon = [UIImage imageNamed:@"icon-folder-external"
+                                  inBundle:browseResourceBundle
+             compatibleWithTraitCollection:nil];
+            } else if (folder.hasCollaborations == BOXAPIBooleanYES) {
+                icon = [UIImage imageNamed:@"icon-folder-shared"
+                                  inBundle:browseResourceBundle
+             compatibleWithTraitCollection:nil];
+            } else {
+                icon = [UIImage imageNamed:@"icon-folder"
+                                  inBundle:browseResourceBundle
+             compatibleWithTraitCollection:nil];
+            }
+        } else if (item.isFile) {
+            NSString *extension = [item.name box_pathExtensionAccountingForZippedPackages].lowercaseString;
+            NSString *imageName = [NSString stringWithFormat:@"icon-file-%@", extension];
+            icon = [UIImage imageNamed:imageName
+                              inBundle:browseResourceBundle
+         compatibleWithTraitCollection:nil];
+            if (icon == nil) {
+                icon = [UIImage imageNamed:@"icon-file-generic"
+                                  inBundle:browseResourceBundle
+             compatibleWithTraitCollection:nil];
+            }
+        } else if (item.isBookmark) {
+            icon = [UIImage imageNamed:@"icon-file-weblink"
+                              inBundle:browseResourceBundle
+         compatibleWithTraitCollection:nil];
         }
-    } else if (item.isFile) {
-        NSString *extension = [item.name box_pathExtensionAccountingForZippedPackages].lowercaseString;
-        NSString *imageName = [NSString stringWithFormat:@"icon-file-%@", extension];
-        icon = [UIImage imageNamed:imageName inBundle:browseResourceBundle compatibleWithTraitCollection:nil];
-        if (icon == nil) {
-            icon = [UIImage imageNamed:@"icon-file-generic" inBundle:browseResourceBundle compatibleWithTraitCollection:nil];
-        }
-    } else if (item.isBookmark) {
-        icon = [UIImage imageNamed:@"icon-file-weblink" inBundle:browseResourceBundle compatibleWithTraitCollection:nil];
     }
 
     return icon;


### PR DESCRIPTION
Apple's documentation says that imageNamed:inBundle:compatibleWithTraitCollection:
is thread safe as of iOS 9. We are seeing crashes in both iOS 8 and 9 on calling
it, and it is always in process on another thread (or more) as well. It is possible
that Apple's iOS 9 fix does not make it thread safe in all scenarios.
Additionally, the NSBundle object returned will be the same most of the time,
from Apple's documentation: "This method allocates and initializes the returned
object if there is no existing NSBundle associated with fullPath, in which case
it returns the existing object."