### PR TITLE
Make sure Google Slides files get handles as a Presentation file type

### DIFF
--- a/BoxBrowseSDK/BoxBrowseSDK/Helpers/BOXBrowseSDKFileTypeHelper.m
+++ b/BoxBrowseSDK/BoxBrowseSDK/Helpers/BOXBrowseSDKFileTypeHelper.m
@@ -103,7 +103,7 @@
     static NSSet *extensions = nil;
     
     if (extensions == nil) {
-        extensions = [NSSet setWithObjects:@"gslide", @"key", @"keynote", @"opd", @"otp", @"pot", @"potx", @"ppt", @"pptx", nil];
+        extensions = [NSSet setWithObjects:@"gslide", @"gslides", @"key", @"keynote", @"opd", @"otp", @"pot", @"potx", @"ppt", @"pptx", nil];
     }
     
     return extensions;


### PR DESCRIPTION
There seem to be 2 valid extensions for Google Slides: .gslide and .gslides
The plural .gslides is used more predominantly by Google now.