### PR TITLE
IOS-16566 - Avoid the bug by not adding the UIRefreshControl

### DIFF
--- a/BoxBrowseSDK/BoxBrowseSDK/Controllers/BOXItemsViewController.h
+++ b/BoxBrowseSDK/BoxBrowseSDK/Controllers/BOXItemsViewController.h
@@ -36,6 +36,7 @@
  * Refresh the items shown.
  */
 - (void)refresh;
+- (void)installRefreshControl;
 
 @end
 

--- a/BoxBrowseSDK/BoxBrowseSDK/Controllers/BOXItemsViewController.m
+++ b/BoxBrowseSDK/BoxBrowseSDK/Controllers/BOXItemsViewController.m
@@ -206,9 +206,7 @@
                 self.items = items;
                 [self.tableView reloadData];
             }
-            if (self.refreshControl) {
-                [self.refreshControl endRefreshing];
-            }
+            [self.refreshControl endRefreshing];
         }
     }];
 }

--- a/BoxBrowseSDK/BoxBrowseSDK/Controllers/BOXItemsViewController.m
+++ b/BoxBrowseSDK/BoxBrowseSDK/Controllers/BOXItemsViewController.m
@@ -40,7 +40,11 @@
     self.tableView.separatorColor = [UIColor colorWithWhite:244.0f/255.0f alpha:1.0f];
     
     [self setupNavigationBar];
-    
+    [self installRefreshControl];
+}
+
+-(void)installRefreshControl
+{
     self.refreshControl = [[UIRefreshControl alloc] init];
     [self.refreshControl addTarget:self action:@selector(refresh) forControlEvents:UIControlEventValueChanged];
 }
@@ -202,7 +206,9 @@
                 self.items = items;
                 [self.tableView reloadData];
             }
-            [self.refreshControl endRefreshing];
+            if (self.refreshControl) {
+                [self.refreshControl endRefreshing];
+            }
         }
     }];
 }

--- a/BoxBrowseSDK/BoxBrowseSDK/Controllers/BOXSearchResultsViewController.m
+++ b/BoxBrowseSDK/BoxBrowseSDK/Controllers/BOXSearchResultsViewController.m
@@ -28,6 +28,12 @@
     [self refresh];
 }
 
+-(void)installRefreshControl
+{
+    // override to prevent the installation of the UIRefreshControl
+    // which is causing IOS-16566
+}
+
 - (void)dealloc
 {
     [self.searchRequest cancel];


### PR DESCRIPTION
Apparently adding the UIRefreshControl to the BOXSearchResultsViewController
is causing the `Cancel` button to not be initialially functional.
The reason for this is unknown. This commit resolves this issue
by removing this ability (to 'refresh') while the search control
is active.